### PR TITLE
chore(pr-template): add standardized pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+Short description of the change in plain language.
+
+## Details
+- What was changed
+- Why it was changed (context / reasoning)
+
+## Issue
+Link the related issue(s) using closing keywords.  
+Example: `Closes #XX`
+
+## Testing
+- Steps followed to test this change
+- Evidence (screenshots, logs, results) if useful
+
+## Notes
+- Risks, limitations, or rollback plan (if relevant)
+- Follow-up tasks or related work
+
+## Checklist
+- [ ] Tests added/updated if applicable
+- [ ] Documentation updated if applicable
+- [ ] CI/CD pipeline passes


### PR DESCRIPTION
Closes #25

Adds `.github/pull_request_template.md` with enterprise-style sections:
- Summary
- Details
- Issue linkage
- Testing
- Notes
- Checklist for hygiene (tests/docs/CI)

This ensures consistent PR formatting and traceability across the repo.
