### PR TITLE
Chore/docs issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: "🐛 Bug Report"
+about: Report a bug or unexpected behavior
+title: "bug: "
+labels: ["fix"]
+---
+
+## Description
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happened.
+
+## Environment
+- OS:
+- Browser:
+- Other relevant details:
+
+## Notes
+Optional: logs, screenshots, or related issues.

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,18 @@
+---
+name: "🛠️ Chore / Maintenance"
+about: Improvements to tooling, config, or repo hygiene
+title: "chore: "
+labels: ["chore"]
+---
+
+## Summary
+Describe the maintenance task.
+
+## Rationale
+Why this is needed.
+
+## Impact
+What areas of the repo or workflow are affected?
+
+## Notes
+Optional additional details.

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,18 @@
+---
+name: "📖 Documentation Update"
+about: Propose or track changes to documentation
+title: "docs: "
+labels: ["docs"]
+---
+
+## Summary
+Brief description of the documentation update.
+
+## Motivation
+Why this update is needed (clarity, completeness, accuracy, onboarding).
+
+## Scope
+Which docs need to be updated? (README, ADRs, API docs, etc.)
+
+## Notes
+Optional details, references, or related issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: "✨ Feature Request"
+about: Suggest a new feature or improvement
+title: "feat: "
+labels: ["feat"]
+---
+
+## Summary
+Brief description of the feature.
+
+## Motivation
+Why is this feature needed?
+
+## Detailed Explanation
+Describe how you’d like it to work.
+
+## Alternatives
+Any alternative solutions you’ve considered?
+
+## Notes
+Additional context or references.

--- a/README.md
+++ b/README.md
@@ -140,14 +140,25 @@ chore(ci): update GitHub Actions cache key
 - Docker Compose for local Postgres, dev services
 - ADRs + Business Logic Docs in `/docs`
 
+## Architecture Decision Records (ADRs)
+
+Key technical decisions for this project are documented as ADRs under [`/docs/adr/`].
+
+Each ADR follows the [Nygard format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions), capturing context, decision, and consequences.
+
+Current ADRs:
+- ADR-0001: Rails 8 with Postgres (full mode, JSON APIs)
+- ADR-0002: React 18 + Vite + Tailwind frontend (hybrid with Rails backend)
+- ADR-0003: GitHub Projects (beta) for project management
+
 ---
 
 ## Getting Started
 
 ### Prerequisites
-- Ruby 3.3+ and Rails 8  
-- Node 20+  
-- PostgreSQL 14+ (local or Docker)  
+- Ruby 3.3+ and Rails 8
+- Node 20+
+- PostgreSQL 14+ (local or Docker)
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Current ADRs:
 - ADR-0001: Rails 8 with Postgres (full mode, JSON APIs)
 - ADR-0002: React 18 + Vite + Tailwind frontend (hybrid with Rails backend)
 - ADR-0003: GitHub Projects (beta) for project management
+- ADR-0004: RSpec as test framework (with FactoryBot, Faker, Shoulda)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a Vulnerability
+If you discover a security vulnerability, please report it responsibly.
+
+- Do not open public issues for security concerns.
+- Instead, email: [your contact email or GitHub profile link]
+
+We will acknowledge receipt and investigate promptly.
+
+## Security Scans
+Dependencies are scanned regularly as part of CI/CD:
+- Ruby: `bundler audit`
+- Node.js: `npm audit`
+
+Scans are informational in this project but demonstrate enterprise workflow hygiene.
+
+## Branch Protection
+The `main` branch is protected with:
+- Required pull requests before merging
+- Direct commits to `main` are disallowed
+- Linear history is enforced (squash/rebase only, no merge commits)
+- Deletions of `main` are disallowed
+- Force pushes to `main` are blocked
+- No bypasses are configured (equivalent to including administrators)
+- Status checks will be required once CI/CD is configured

--- a/docs/adr/.keep
+++ b/docs/adr/.keep
@@ -1,2 +1,0 @@
-This file ensures the adr/ directory is tracked in Git.
-Delete this file once real documentation is added.

--- a/docs/adr/0001-rails-postgres.md
+++ b/docs/adr/0001-rails-postgres.md
@@ -1,0 +1,22 @@
+# ADR-0001: Use Rails 8 with Postgres (Full Mode, JSON APIs)
+
+**Status:** Accepted
+
+## Context
+We need a backend framework that supports robust domain modeling, rich text, and file uploads while providing JSON APIs for a React frontend. Rails 8 offers modern defaults, security features, and a mature ActiveRecord ORM. Postgres provides reliability, indexing, and enterprise adoption.
+
+## Decision
+We will use Rails 8 in full mode (not API-only), exposing JSON APIs as the primary interface. This ensures flexibility for hybrid approaches, including server-rendered views if needed.
+
+## Consequences
+- **Positive:**  
+  - Full Rails stack available (views, ActionText, ActiveStorage, mailers)
+  - JSON APIs work seamlessly with React frontend
+  - Flexibility for hybrid rendering or admin-only views in future
+- **Negative:**  
+  - Slightly larger footprint than API-only mode  
+  - Must ensure frontend-only routes and backend views don’t conflict  
+- **Alternatives:**  
+  - Rails API-only + React → Leaner, but less flexible  
+  - Django + Postgres → Similar enterprise maturity, but weaker ecosystem for ActionText-style features  
+  - Express.js + Node → Lighter, but weaker ORM and enterprise discipline

--- a/docs/adr/0002-react-vite-tailwind.md
+++ b/docs/adr/0002-react-vite-tailwind.md
@@ -1,0 +1,22 @@
+# ADR-0002: Use React 18 + Vite + Tailwind frontend
+
+**Status:** Accepted
+
+## Context
+The application will use a hybrid approach: Rails 8 provides the backend and JSON APIs, while React 18 will handle the main user-facing frontend. Rails retains the ability to render server-side views if needed (e.g., admin interfaces, email previews, fallbacks). React is chosen to deliver a responsive SPA experience, with Vite for modern build tooling and Tailwind for consistent styling.
+
+## Decision
+We will implement the primary user interface using React 18 with Vite as the bundler/build tool, and Tailwind CSS for styling. Rails will continue to serve JSON APIs and may support limited server-rendered views for specific use cases.
+
+## Consequences
+- **Positive:**  
+  - Fast developer experience with Vite  
+  - Enterprise adoption of React, recruiter familiarity  
+  - Tailwind utility classes provide consistent styling  
+  - Rails remains available for hybrid server-rendered needs  
+- **Negative:**  
+  - Requires clear separation of Rails routes vs React SPA routes  
+  - Tailwind can clutter markup if not disciplined  
+  - React has a larger bundle size compared to lighter frameworks  
+- **Alternatives:**  
+  - Angular, Vue, or Svelte. Chosen React for ecosystem, team/recruiter familiarity, and flexibility with Rails hybrid.

--- a/docs/adr/0003-github-projects.md
+++ b/docs/adr/0003-github-projects.md
@@ -1,0 +1,20 @@
+# ADR-0003: Use GitHub Projects (beta) for project management
+
+**Status:** Accepted
+
+## Context
+We need a lightweight but enterprise-grade project management solution integrated with GitHub Issues and PRs. GitHub Projects (beta) provides customizable fields, workflows, and views (board, table, roadmap) without requiring an external tool.
+
+## Decision
+We will use GitHub Projects (beta) as the source of truth for backlog management, estimation, epics, and milestones.
+
+## Consequences
+- **Positive:**  
+  - Native GitHub integration  
+  - Automated workflows  
+  - Transparent for recruiters and maintainers  
+  - Minimal overhead  
+- **Negative:**  
+  - Fewer features than Jira/Linear (limited reporting, automation quirks)  
+- **Alternatives:**  
+  - Jira, Linear, Trello. Chosen GitHub Projects due to tight repo integration and solo developer context.


### PR DESCRIPTION
## Summary
Add documentation issue template for consistency in tracking doc-related work.

## Details
- Created `.github/ISSUE_TEMPLATE/docs.md`
- Template includes Summary, Motivation, Scope, and Notes sections
- Applies `docs` label automatically
- Future ADRs and documentation tasks will use this template

## Issue
Closes #30

## Testing
- Verified the template appears in GitHub "New Issue" picker
- Checked auto-labeling applies `docs` correctly

## Notes
- Completes governance polish alongside bug/feature/chore templates
- First doc issue to use this template will be ADR: Choose test framework (#31)

## Checklist
- [x] Template file created
- [x] Label auto-applied
- [x] Verified issue picker shows new template
