### PR TITLE
docs(adr): add ADR-0004 RSpec as test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Current ADRs:
 - ADR-0001: Rails 8 with Postgres (full mode, JSON APIs)
 - ADR-0002: React 18 + Vite + Tailwind frontend (hybrid with Rails backend)
 - ADR-0003: GitHub Projects (beta) for project management
+- ADR-0004: RSpec as test framework (with FactoryBot, Faker, Shoulda)
 
 ---
 

--- a/docs/adr/0004-test-framework.md
+++ b/docs/adr/0004-test-framework.md
@@ -1,0 +1,21 @@
+# ADR-0004: Choose RSpec for Testing Framework
+
+**Status:** Accepted
+
+## Context
+Rails defaults to Minitest, which is lightweight and built-in. However, enterprise Rails teams commonly use RSpec due to its rich DSL, ecosystem, and readability for behavior-driven tests. This project aims to demonstrate enterprise-grade practices while being maintained by a solo developer.
+
+## Decision
+We will use RSpec as the testing framework, alongside FactoryBot, Faker, and Shoulda Matchers for factories, test data, and expressive model/controller matchers.
+
+## Consequences
+- **Positive:**  
+  - Familiar to enterprise teams and recruiters  
+  - Large ecosystem of gems and plugins  
+  - Readable DSL for specs (`describe`, `context`, `it`)  
+- **Negative:**  
+  - Heavier than Minitest  
+  - Slightly slower startup times compared to built-in Minitest  
+- **Alternatives:**  
+  - **Minitest** → Lightweight, included by default, but less enterprise optics  
+  - **TestUnit/other DSLs** → Rare in Rails, little ecosystem support


### PR DESCRIPTION
**Summary**  
Adds an Architecture Decision Record (ADR-0004) documenting the decision to adopt **RSpec** as the project’s testing framework.  

**Details**  
- Added new ADR file: `docs/adr/0004-test-framework.md`  
- Captures context, decision, and consequences of selecting RSpec over Minitest  
- Documents supporting libraries: FactoryBot, Faker, and Shoulda Matchers  
- Provides reasoning: enterprise familiarity, readable DSL, rich ecosystem  

**Issue**  
Closes #38  

**Testing**  
- Verified ADR file renders correctly in Markdown  
- Confirmed numbering is consistent with existing ADR sequence in README  
- No application code or runtime behavior modified  

**Notes**  
- Documentation-only change, no runtime risk  
- Rollback plan: remove ADR file if direction changes  
- Future tasks: scaffold RSpec setup (Gemfile, `spec/` directory, `rails_helper.rb`) in a separate PR  

**Checklist**  
- [x] Tests added/updated if applicable (N/A – documentation only)  
- [x] Documentation updated (ADR created)  
- [x] CI/CD pipeline passes (expected to pass – no code changes)  

